### PR TITLE
Fix 'settings' module passed to dictor() instead of settings.SAML2_AUTH

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -51,3 +51,4 @@ If your code or changes are here, but you are not mentioned, please open an issu
 - `chriskj <https://github.com/chriskj>`_
 - `Griffin J Rademacher <https://github.com/favorable-mutation>`_
 - `Akshit Dhar <https://github.com/akshit-wwstay>`_
+- ` Jean Vincent <https://github.com/jean-sh>`_

--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -285,11 +285,12 @@ def extract_user_identity(user_identity: Dict[str, Any]) -> Dict[str, Optional[A
         Dict[str, Optional[Any]]: Cleaned user information plus user_identity
             for backwards compatibility
     """
-    email_field = dictor(settings, "ATTRIBUTES_MAP.email", default="user.email")
-    username_field = dictor(settings, "ATTRIBUTES_MAP.username", default="user.username")
-    firstname_field = dictor(settings, "ATTRIBUTES_MAP.first_name", default="user.first_name")
-    lastname_field = dictor(settings, "ATTRIBUTES_MAP.last_name", default="user.last_name")
-    token_field = dictor(settings, "ATTRIBUTES_MAP.token", default="token")
+    saml2_auth_settings = settings.SAML2_AUTH
+    email_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.email", default="user.email")
+    username_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.username", default="user.username")
+    firstname_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.first_name", default="user.first_name")
+    lastname_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.last_name", default="user.last_name")
+    token_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.token", default="token")
 
     user = {}
     user["email"] = dictor(user_identity, f"{email_field}/0", pathsep="/")  # Path includes "."


### PR DESCRIPTION
The django settings module itself is currently passed to `dictor` in `extract_user_identity` for retrieving the attributes field from `ATTRIBUTES_MAP`, instead of the `SAML2_AUTH` dictionary from the settings.

This causes all fields to be assigned their default value and the attribute mapping to not work.

This PR fixes that by passing `settings.SAML2_AUTH` to `dictor`.