### PR TITLE
Fix "Location" header access in signin view

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -172,11 +172,7 @@ def signin(request: HttpRequest):
     saml_client = get_saml_client(get_assertion_url(request), acs)
     _, info = saml_client.prepare_for_authenticate(relay_state=next_url)
 
-    redirect_url = None
-
-    if "Location" in info["headers"]:
-        redirect_url = info["headers"]["Location"]
-
+    redirect_url = dict(info["headers"]).get("Location", "")
     return HttpResponseRedirect(redirect_url)
 
 


### PR DESCRIPTION
In the `signin` view, the headers are a list of tuples of the form `[(header_name, header_value)...]` but the Location header is accessed as if it was a dictionary.

This PR fixes this by converting the list to a dictionary before retrieving the Location header. This mirrors what is done in `sp_initiated_login`.