### PR TITLE
Feature: make token field optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ How to use?
                 'username': 'UserName',
                 'first_name': 'FirstName',
                 'last_name': 'LastName',
-                'token': 'Token',  # Mandatory
+                'token': 'Token',  # Mandatory, can be unrequired if REQUIRE_TOKEN is False
                 'groups': 'Groups',  # Optional
             },
             'GROUPS_MAP': {  # Optionally allow mapping SAML2 Groups to Django Groups
@@ -158,6 +158,7 @@ How to use?
             'WANT_ASSERTIONS_SIGNED': True,  # Require each assertion to be signed
             'WANT_RESPONSE_SIGNED': False,  # Require response to be signed
             'ALLOWED_REDIRECT_HOSTS': ["https://myfrontendclient.com"] # Allowed hosts to redirect to using the ?next parameter
+            'REQUIRE_TOKEN': True,  # Whether or not to require the token parameter in the SAML assertion
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience URI (SP Entity ID) to http://your-domain/saml2_auth/acs/
@@ -220,6 +221,8 @@ With these params your client can now authenticate with server resources.
 **WANT_RESPONSE_SIGNED** Set this to the boolean True if you require your provider to sign the response.
 
 **ACCEPTED_TIME_DIFF** Sets the accepted time diff in seconds `PySaml2 Accepted Time Diff <https://pysaml2.readthedocs.io/en/latest/howto/config.html#accepted-time-diff>`_
+
+**REQUIRE_TOKEN** Set this to the boolean False if you don't require the token parameter in the SAML assertion.
 
 Customize
 =========

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ How to use?
                 'username': 'UserName',
                 'first_name': 'FirstName',
                 'last_name': 'LastName',
-                'token': 'Token',  # Mandatory, can be unrequired if REQUIRE_TOKEN is False
+                'token': 'Token',  # Mandatory, can be unrequired if TOKEN_REQUIRED is False
                 'groups': 'Groups',  # Optional
             },
             'GROUPS_MAP': {  # Optionally allow mapping SAML2 Groups to Django Groups
@@ -158,7 +158,7 @@ How to use?
             'WANT_ASSERTIONS_SIGNED': True,  # Require each assertion to be signed
             'WANT_RESPONSE_SIGNED': False,  # Require response to be signed
             'ALLOWED_REDIRECT_HOSTS': ["https://myfrontendclient.com"] # Allowed hosts to redirect to using the ?next parameter
-            'REQUIRE_TOKEN': True,  # Whether or not to require the token parameter in the SAML assertion
+            'TOKEN_REQUIRED': True,  # Whether or not to require the token parameter in the SAML assertion
         }
 
 #. In your SAML2 SSO identity provider, set the Single-sign-on URL and Audience URI (SP Entity ID) to http://your-domain/saml2_auth/acs/
@@ -222,7 +222,7 @@ With these params your client can now authenticate with server resources.
 
 **ACCEPTED_TIME_DIFF** Sets the accepted time diff in seconds `PySaml2 Accepted Time Diff <https://pysaml2.readthedocs.io/en/latest/howto/config.html#accepted-time-diff>`_
 
-**REQUIRE_TOKEN** Set this to the boolean False if you don't require the token parameter in the SAML assertion.
+**TOKEN_REQUIRED** Set this to the boolean False if you don't require the token parameter in the SAML assertion.
 
 Customize
 =========

--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -292,18 +292,26 @@ def extract_user_identity(user_identity: Dict[str, Any]) -> Dict[str, Optional[A
             for backwards compatibility
     """
     saml2_auth_settings = settings.SAML2_AUTH
-    email_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.email", default="user.email")
-    username_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.username", default="user.username")
-    firstname_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.first_name", default="user.first_name")
-    lastname_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.last_name", default="user.last_name")
-    token_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.token", default="token")
+
+    email_field = dictor(
+        saml2_auth_settings, "ATTRIBUTES_MAP.email", default="user.email")
+    username_field = dictor(
+        saml2_auth_settings, "ATTRIBUTES_MAP.username", default="user.username")
+    firstname_field = dictor(
+        saml2_auth_settings, "ATTRIBUTES_MAP.first_name", default="user.first_name")
+    lastname_field = dictor(
+        saml2_auth_settings, "ATTRIBUTES_MAP.last_name", default="user.last_name")
 
     user = {}
     user["email"] = dictor(user_identity, f"{email_field}/0", pathsep="/")  # Path includes "."
     user["username"] = dictor(user_identity, f"{username_field}/0", pathsep="/")
     user["first_name"] = dictor(user_identity, f"{firstname_field}/0", pathsep="/")
     user["last_name"] = dictor(user_identity, f"{lastname_field}/0", pathsep="/")
-    user["token"] = dictor(user_identity, f"{token_field}.0")
+
+    require_token = dictor(saml2_auth_settings, "REQUIRE_TOKEN", default=True)
+    if require_token:
+        token_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.token", default="token")
+        user["token"] = dictor(user_identity, f"{token_field}.0")
 
     if user["email"]:
         user["email"] = user["email"].lower()
@@ -321,7 +329,7 @@ def extract_user_identity(user_identity: Dict[str, Any]) -> Dict[str, Optional[A
             "status_code": 422
         })
 
-    if not user["token"]:
+    if require_token and not user.get("token"):
         raise SAMLAuthError("No token specified.", extra={
             "exc_type": ValueError,
             "error_code": NO_TOKEN_SPECIFIED,

--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -308,8 +308,8 @@ def extract_user_identity(user_identity: Dict[str, Any]) -> Dict[str, Optional[A
     user["first_name"] = dictor(user_identity, f"{firstname_field}/0", pathsep="/")
     user["last_name"] = dictor(user_identity, f"{lastname_field}/0", pathsep="/")
 
-    require_token = dictor(saml2_auth_settings, "REQUIRE_TOKEN", default=True)
-    if require_token:
+    TOKEN_REQUIRED = dictor(saml2_auth_settings, "TOKEN_REQUIRED", default=True)
+    if TOKEN_REQUIRED:
         token_field = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.token", default="token")
         user["token"] = dictor(user_identity, f"{token_field}.0")
 
@@ -329,7 +329,7 @@ def extract_user_identity(user_identity: Dict[str, Any]) -> Dict[str, Optional[A
             "status_code": 422
         })
 
-    if require_token and not user.get("token"):
+    if TOKEN_REQUIRED and not user.get("token"):
         raise SAMLAuthError("No token specified.", extra={
             "exc_type": ValueError,
             "error_code": NO_TOKEN_SPECIFIED,

--- a/django_saml2_auth/tests/settings.py
+++ b/django_saml2_auth/tests/settings.py
@@ -100,5 +100,5 @@ SAML2_AUTH = {
     "ALLOWED_REDIRECT_HOSTS": ["https://app.example.com",
                                "https://api.example.com",
                                "https://example.com"],
-    "REQUIRE_TOKEN": True
+    "TOKEN_REQUIRED": True
 }

--- a/django_saml2_auth/tests/settings.py
+++ b/django_saml2_auth/tests/settings.py
@@ -99,5 +99,6 @@ SAML2_AUTH = {
     "WANT_RESPONSE_SIGNED": True,
     "ALLOWED_REDIRECT_HOSTS": ["https://app.example.com",
                                "https://api.example.com",
-                               "https://example.com"]
+                               "https://example.com"],
+    "REQUIRE_TOKEN": True
 }

--- a/django_saml2_auth/tests/test_saml.py
+++ b/django_saml2_auth/tests/test_saml.py
@@ -185,7 +185,7 @@ def test_validate_metadata_url_failure():
     URL."""
     responses.add(responses.GET, METADATA_URL1)
     result = validate_metadata_url(METADATA_URL1)
-    assert result == False
+    assert result is False
 
 
 @responses.activate
@@ -365,3 +365,13 @@ def test_extract_user_identity_success():
     assert result["last_name"] == "Doe"
     assert result["token"] == "TOKEN"
     assert result["user_identity"] == get_user_identity()
+
+
+def test_extract_user_identity_token_not_required(settings: SettingsWrapper):
+    """Test extract_user_identity function to verify if it correctly extracts user identity
+    information from a (pysaml2) parsed SAML response when token is not required."""
+    settings.SAML2_AUTH["TOKEN_REQUIRED"] = False
+
+    result = extract_user_identity(get_user_identity())
+    assert len(result) == 5
+    assert "token" not in result


### PR DESCRIPTION
Based on the discussion on the issue #20, I decided to make the `token` field optional based on the `TOKEN_REQUIRED` field. If unset, it will make the `token` field optional.

@JVemmer @jean-sh I'd be happy to have your feedback.