### PR TITLE
Use settings.SAML2_AUTH in calls to dictor

### DIFF
--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -149,10 +149,12 @@ def get_saml_client(domain: str,
             "status_code": 500
         })
 
+    saml2_auth_settings = settings.SAML2_AUTH
+
     saml_settings = {
         "metadata": metadata,
         "allow_unknown_attributes": True,
-        "debug": settings.SAML2_AUTH.get("DEBUG", False),
+        "debug": saml2_auth_settings.get("DEBUG", False),
         "service": {
             "sp": {
                 "endpoints": {
@@ -163,28 +165,28 @@ def get_saml_client(domain: str,
                 },
                 "allow_unsolicited": True,
                 "authn_requests_signed": dictor(
-                    settings, "SAML2_AUTH.AUTHN_REQUESTS_SIGNED", default=True),
+                    saml2_auth_settings, "AUTHN_REQUESTS_SIGNED", default=True),
                 "logout_requests_signed": dictor(
-                    settings, "SAML2_AUTH.LOGOUT_REQUESTS_SIGNED", default=True),
+                    saml2_auth_settings, "LOGOUT_REQUESTS_SIGNED", default=True),
                 "want_assertions_signed": dictor(
-                    settings, "SAML2_AUTH.WANT_ASSERTIONS_SIGNED", default=True),
+                    saml2_auth_settings, "WANT_ASSERTIONS_SIGNED", default=True),
                 "want_response_signed": dictor(
-                    settings, "SAML2_AUTH.WANT_RESPONSE_SIGNED", default=True),
+                    saml2_auth_settings, "WANT_RESPONSE_SIGNED", default=True),
             },
         },
     }
 
-    entity_id = settings.SAML2_AUTH.get("ENTITY_ID")
+    entity_id = saml2_auth_settings.get("ENTITY_ID")
     if entity_id:
         saml_settings["entityid"] = entity_id
 
-    name_id_format = settings.SAML2_AUTH.get("NAME_ID_FORMAT")
+    name_id_format = saml2_auth_settings.get("NAME_ID_FORMAT")
     if name_id_format:
         saml_settings["service"]["sp"]["name_id_format"] = name_id_format
 
-    accepted_time_diff = settings.SAML2_AUTH.get("ACCEPTED_TIME_DIFF")
+    accepted_time_diff = saml2_auth_settings.get("ACCEPTED_TIME_DIFF")
     if accepted_time_diff:
-        saml_settings['accepted_time_diff'] = settings.SAML2_AUTH['ACCEPTED_TIME_DIFF']
+        saml_settings['accepted_time_diff'] = accepted_time_diff
 
     try:
         sp_config = Saml2Config()

--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -28,7 +28,8 @@ def get_assertion_url(request: HttpRequest) -> str:
     Returns:
         str: Either protocol://host or ASSERTION_URL
     """
-    assertion_url = settings.SAML2_AUTH.get("ASSERTION_URL")
+    saml2_auth_settings = settings.SAML2_AUTH
+    assertion_url = dictor(saml2_auth_settings, "ASSERTION_URL")
     if assertion_url:
         return assertion_url
 
@@ -44,7 +45,8 @@ def get_default_next_url() -> Optional[str]:
     Returns:
         Optional[str]: Returns default next url for redirection or admin index
     """
-    default_next_url = settings.SAML2_AUTH.get("DEFAULT_NEXT_URL")
+    saml2_auth_settings = settings.SAML2_AUTH
+    default_next_url = dictor(saml2_auth_settings, "DEFAULT_NEXT_URL")
     if default_next_url:
         return default_next_url
 
@@ -89,7 +91,8 @@ def get_metadata(user_id: Optional[str] = None) -> Mapping[str, Any]:
     Returns:
         Mapping[str, Any]: Returns a SAML metadata object as dictionary
     """
-    get_metadata_trigger = dictor(settings.SAML2_AUTH, "TRIGGER.GET_METADATA_AUTO_CONF_URLS")
+    saml2_auth_settings = settings.SAML2_AUTH
+    get_metadata_trigger = dictor(saml2_auth_settings, "TRIGGER.GET_METADATA_AUTO_CONF_URLS")
     if get_metadata_trigger:
         metadata_urls = run_hook(get_metadata_trigger, user_id)
         if metadata_urls:
@@ -106,11 +109,11 @@ def get_metadata(user_id: Optional[str] = None) -> Mapping[str, Any]:
                                     "status_code": 500
                                 })
 
-    metadata_local_file_path = settings.SAML2_AUTH.get("METADATA_LOCAL_FILE_PATH")
+    metadata_local_file_path = dictor(saml2_auth_settings, "METADATA_LOCAL_FILE_PATH")
     if metadata_local_file_path:
         return {"local": [metadata_local_file_path]}
     else:
-        single_metadata_url = settings.SAML2_AUTH.get("METADATA_AUTO_CONF_URL")
+        single_metadata_url = dictor(saml2_auth_settings, "METADATA_AUTO_CONF_URL")
         if validate_metadata_url(single_metadata_url):
             return {"remote": [{"url": single_metadata_url}]}
         else:

--- a/django_saml2_auth/user.py
+++ b/django_saml2_auth/user.py
@@ -39,12 +39,13 @@ def create_new_user(email: str, firstname: str, lastname: str) -> Type[Model]:
     Returns:
         Type[Model]: Returns a new user object, usually a subclass of the the User model
     """
+    saml2_auth_settings = settings.SAML2_AUTH
     user_model = get_user_model()
 
-    is_active = dictor(settings.SAML2_AUTH, "NEW_USER_PROFILE.ACTIVE_STATUS", default=True)
-    is_staff = dictor(settings.SAML2_AUTH, "NEW_USER_PROFILE.STAFF_STATUS", default=False)
-    is_superuser = dictor(settings.SAML2_AUTH, "NEW_USER_PROFILE.SUPERUSER_STATUS", default=False)
-    user_groups = dictor(settings.SAML2_AUTH, "NEW_USER_PROFILE.USER_GROUPS", default=[])
+    is_active = dictor(saml2_auth_settings, "NEW_USER_PROFILE.ACTIVE_STATUS", default=True)
+    is_staff = dictor(saml2_auth_settings, "NEW_USER_PROFILE.STAFF_STATUS", default=False)
+    is_superuser = dictor(saml2_auth_settings, "NEW_USER_PROFILE.SUPERUSER_STATUS", default=False)
+    user_groups = dictor(saml2_auth_settings, "NEW_USER_PROFILE.USER_GROUPS", default=[])
 
     try:
         user = user_model.objects.create_user(email, first_name=firstname, last_name=lastname)
@@ -95,17 +96,18 @@ def get_or_create_user(user: Dict[str, Any]) -> Tuple[bool, Type[Model]]:
     Returns:
         Tuple[bool, Type[Model]]: A tuple containing user creation status and user object
     """
+    saml2_auth_settings = settings.SAML2_AUTH
     user_model = get_user_model()
     created = False
 
     try:
         target_user = get_user(user)
     except user_model.DoesNotExist:
-        should_create_new_user = settings.SAML2_AUTH.get("CREATE_USER", True)
+        should_create_new_user = dictor(saml2_auth_settings, "CREATE_USER", True)
         if should_create_new_user:
             target_user = create_new_user(get_user_id(user), user["first_name"], user["last_name"])
 
-            create_user_trigger = dictor(settings.SAML2_AUTH, "TRIGGER.CREATE_USER")
+            create_user_trigger = dictor(saml2_auth_settings, "TRIGGER.CREATE_USER")
             if create_user_trigger:
                 run_hook(create_user_trigger, user)
 
@@ -121,8 +123,8 @@ def get_or_create_user(user: Dict[str, Any]) -> Tuple[bool, Type[Model]]:
 
     # Optionally update this user's group assignments by updating group memberships from SAML groups
     # to Django equivalents
-    group_attribute = dictor(settings.SAML2_AUTH, "ATTRIBUTES_MAP.groups")
-    group_map = settings.SAML2_AUTH.get("GROUPS_MAP")
+    group_attribute = dictor(saml2_auth_settings, "ATTRIBUTES_MAP.groups")
+    group_map = dictor(saml2_auth_settings, "GROUPS_MAP")
 
     if group_attribute and group_attribute in user["user_identity"]:
         groups = []
@@ -177,11 +179,12 @@ def get_user(user: Union[str, Dict[str, str]]) -> Type[Model]:
     Returns:
         Type[Model]: An instance of the User model
     """
+    saml2_auth_settings = settings.SAML2_AUTH
     user_model = get_user_model()
     user_id = get_user_id(user)
 
     # Should email be case-sensitive or not. Default is False (case-insensitive).
-    login_case_sensitive = settings.SAML2_AUTH.get("LOGIN_CASE_SENSITIVE", False)
+    login_case_sensitive = dictor(saml2_auth_settings, "LOGIN_CASE_SENSITIVE", False)
     id_field = (
         user_model.USERNAME_FIELD
         if login_case_sensitive
@@ -282,19 +285,21 @@ def create_jwt_token(user_id: str) -> Optional[str]:
     Returns:
         Optional[str]: JWT token
     """
+    saml2_auth_settings = settings.SAML2_AUTH
     user_model = get_user_model()
 
-    jwt_algorithm = settings.SAML2_AUTH.get("JWT_ALGORITHM")
+    jwt_algorithm = dictor(saml2_auth_settings, "JWT_ALGORITHM")
     validate_jwt_algorithm(jwt_algorithm)
 
-    jwt_secret = settings.SAML2_AUTH.get("JWT_SECRET")
+    jwt_secret = dictor(saml2_auth_settings, "JWT_SECRET")
     validate_secret(jwt_algorithm, jwt_secret)
 
-    jwt_private_key = settings.SAML2_AUTH.get("JWT_PRIVATE_KEY")
+    jwt_private_key = dictor(saml2_auth_settings, "JWT_PRIVATE_KEY")
     validate_private_key(jwt_algorithm, jwt_private_key)
 
-    jwt_private_key_passphrase = settings.SAML2_AUTH.get("JWT_PRIVATE_KEY_PASSPHRASE")
-    jwt_expiration = settings.SAML2_AUTH.get("JWT_EXP", 60)  # default: 1 minute
+    jwt_private_key_passphrase = dictor(saml2_auth_settings, "JWT_PRIVATE_KEY_PASSPHRASE")
+    jwt_expiration = dictor(saml2_auth_settings, "JWT_EXP", 60)  # default: 1 minute
+
     payload = {
         user_model.USERNAME_FIELD: user_id,
         "exp": (datetime.now(tz=timezone.utc) +
@@ -334,13 +339,15 @@ def decode_jwt_token(jwt_token: str) -> Optional[str]:
     Returns:
         Optional[str]: A user_id as str or None.
     """
-    jwt_algorithm = settings.SAML2_AUTH.get("JWT_ALGORITHM")
+    saml2_auth_settings = settings.SAML2_AUTH
+
+    jwt_algorithm = dictor(saml2_auth_settings, "JWT_ALGORITHM")
     validate_jwt_algorithm(jwt_algorithm)
 
-    jwt_secret = settings.SAML2_AUTH.get("JWT_SECRET")
+    jwt_secret = dictor(saml2_auth_settings, "JWT_SECRET")
     validate_secret(jwt_algorithm, jwt_secret)
 
-    jwt_public_key = settings.SAML2_AUTH.get("JWT_PUBLIC_KEY")
+    jwt_public_key = dictor(saml2_auth_settings, "JWT_PUBLIC_KEY")
     validate_public_key(jwt_algorithm, jwt_public_key)
 
     secret = jwt_secret if (


### PR DESCRIPTION
This fixes the same problem as in https://github.com/grafana/django-saml2-auth/pull/19 really, as passing `settings` to `dictor` yields wrong results, i've tried to mirror the code.

Also uses the `accepted_time_diff` variable that is assigned above.

@mostafa are you able to take a look?