### PR TITLE
Add cyclonedx-bom for generating SBOMs for requirements files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,23 @@ jobs:
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball 🏗️
         run: python -m build --sdist --wheel .
+      - name: Generate CycloneDX SBOM artifacts 📃
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        run: |
+          cyclonedx-bom --format json -i requirements.txt -o cyclonedx-${{ github.ref_name }}.json
+          cyclonedx-bom --format json -i requirements_test.txt -o cyclonedx-test-${{ github.ref_name }}.json
+      - name: Upload CycloneDX SBOM artifact for requirements.txt 💾
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyclonedx-${{ github.ref_name }}.json
+          path:
+            cyclonedx-${{ github.ref_name }}.json
+      - name: Upload CycloneDX SBOM artifact for requirements_test.txt 💾
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyclonedx-test-${{ github.ref_name }}.json
+          path:
+            cyclonedx-test-${{ github.ref_name }}.json
       - name: Publish package to PyPI 🎉
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -9,3 +9,4 @@ types-setuptools==57.4.14
 types-pkg-resources==0.1.3
 interrogate==1.5.0
 coveralls==3.3.1
+cyclonedx-bom==3.2.1


### PR DESCRIPTION
The resulting artifacts, [CycloneDX](https://cyclonedx.org/) SBOMs, in this new CI workflow can be used by platforms like [Dependency Track](https://dependencytrack.org/) to track the usage of libraries and their licenses and notify when and if any vulnerability is present or gets introduced when a CVE is released. These artifacts help implement [C-SCRM](https://csrc.nist.gov/Projects/cyber-supply-chain-risk-management) to find supply-chain risks as early as possible.

When a new release is tagged, the artifacts will be generated and uploaded to GitHub artifacts.