### PR TITLE
Adds support for configurable authentication backends

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,3 +52,4 @@ an issue.
 - [Jean Vincent](https://github.com/jean-sh)
 - [Søren Howe Gersager](https://github.com/syre)
 - [Gabrio Mauri](https://github.com/sgabb)
+- [Hugh Enxing](https://github.com/henxing) (CVision AI)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -142,7 +142,9 @@ def acs(request: HttpRequest):
         return HttpResponseRedirect(frontend_url + query)
 
     if target_user.is_active:
-        model_backend = "django.contrib.auth.backends.ModelBackend"
+        model_backend = dictor(
+            settings, "AUTHENTICATION_BACKENDS.0", "django.contrib.auth.backends.ModelBackend"
+        )
         login(request, target_user, model_backend)
 
         after_login_trigger = dictor(saml2_auth_settings, "TRIGGER.AFTER_LOGIN")


### PR DESCRIPTION
This adds support for using the configurable authentication backends
defined in `settings.py` in the `AUTHENTICATION_BACKENDS` list.