### PR TITLE
login page redirect url passed as RelayState instead of "login_next_url

### DIFF
--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -95,7 +95,7 @@ def acs(request: HttpRequest):
     # so we can safely ignore the type check here.
     user = extract_user_identity(authn_response.get_identity())  # type: ignore
 
-    next_url = request.session.get("login_next_url") or get_default_next_url()
+    next_url = request.session.get("login_next_url")
 
     # A RelayState is an HTTP parameter that can be included as part of the SAML request
     # and SAML response; usually is meant to be an opaque identifier that is passed back
@@ -105,6 +105,10 @@ def acs(request: HttpRequest):
     # login via sp_initiated_login endpoint, or it could be a URL used for redirection.
     relay_state = request.POST.get("RelayState")
     relay_state_is_token = is_jwt_well_formed(relay_state) if relay_state else False
+    if next_url is None and relay_state:
+        next_url = relay_state
+    elif next_url is None:
+        next_url = get_default_next_url()
 
     if relay_state and relay_state_is_token:
         redirected_user_id = decode_custom_or_default_jwt(relay_state)


### PR DESCRIPTION
I am using MS-AAD, for admin urls such as  https://dns/admin/django_celery_beat/periodictask/, I enforce login first. 
After login, next url is always assigned to default url as code over here. 

`next_url = request.session.get("login_next_url") or get_default_next_url() `

After login, its POST request to acs where new session gets created so request.session.get("login_next_url") is always None.
However I observed that in such cases next_url is passed as relay_state. 

So to keep existing behaviour and fix the problem, assigning next_url to relay_state if it's None