### PR TITLE
login page redirect url passed as RelayState instead of "login_next_url"

### DIFF
--- a/django_saml2_auth/tests/test_saml.py
+++ b/django_saml2_auth/tests/test_saml.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Mapping
 import pytest
 import responses
 from django.contrib.sessions.middleware import SessionMiddleware
+from unittest.mock import MagicMock
 from django.http import HttpRequest
 from django.test.client import RequestFactory
 from django.urls import NoReverseMatch
@@ -424,7 +425,7 @@ def test_acs_view_when_next_url_is_none(settings: SettingsWrapper, monkeypatch: 
                         "get_or_create_user",
                         (created, mock_user,))
 
-    middleware = SessionMiddleware(lambda x: None)
+    middleware = SessionMiddleware(MagicMock())
     middleware.process_request(post_request)
     post_request.session["login_next_url"] = None
     post_request.session.save()
@@ -467,7 +468,7 @@ def test_acs_view_when_redirection_state_is_passed_in_relay_state(settings: Sett
                         "get_or_create_user",
                         (created, mock_user,))
 
-    middleware = SessionMiddleware(lambda x: None)
+    middleware = SessionMiddleware(MagicMock())
     middleware.process_request(post_request)
     post_request.session["login_next_url"] = None
     post_request.session.save()

--- a/django_saml2_auth/tests/test_saml.py
+++ b/django_saml2_auth/tests/test_saml.py
@@ -6,6 +6,7 @@ from typing import Optional, List, Mapping
 
 import pytest
 import responses
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpRequest
 from django.test.client import RequestFactory
 from django.urls import NoReverseMatch
@@ -18,6 +19,8 @@ from django_saml2_auth.views import acs
 from pytest_django.fixtures import SettingsWrapper
 from saml2.client import Saml2Client
 from saml2.response import AuthnResponse
+from django_saml2_auth import user
+
 
 GET_METADATA_AUTO_CONF_URLS = "django_saml2_auth.tests.test_saml.get_metadata_auto_conf_urls"
 METADATA_URL1 = "https://testserver1.com/saml/sso/metadata"
@@ -386,3 +389,88 @@ def test_extract_user_identity_token_not_required(settings: SettingsWrapper):
     result = extract_user_identity(get_user_identity())  # type: ignore
     assert len(result) == 5
     assert "token" not in result
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_acs_view_when_next_url_is_none(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"): # type: ignore
+    """Test Acs view when login_next_url is None in the session
+    """
+    responses.add(responses.GET, METADATA_URL1, body=METADATA1)
+    settings.SAML2_AUTH = {
+        "ASSERTION_URL": "https://api.example.com",
+        "DEFAULT_NEXT_URL": "default_next_url",
+        "USE_JWT": False,
+        "TRIGGER": {
+            "BEFORE_LOGIN": None,
+            "AFTER_LOGIN": None,
+            "GET_METADATA_AUTO_CONF_URLS": GET_METADATA_AUTO_CONF_URLS
+        }
+    }
+    post_request = RequestFactory().post(METADATA_URL1,
+                                         {"SAMLResponse": "SAML RESPONSE"})
+
+    monkeypatch.setattr(Saml2Client,
+                        "parse_authn_request_response",
+                        mock_parse_authn_request_response)
+
+    created, mock_user = user.get_or_create_user({
+        "username": "test@example.com",
+        "first_name": "John",
+        "last_name": "Doe"
+    })
+
+    monkeypatch.setattr(user,
+                        "get_or_create_user",
+                        (created, mock_user,))
+
+    middleware = SessionMiddleware(lambda x: None)
+    middleware.process_request(post_request)
+    post_request.session["login_next_url"] = None
+    post_request.session.save()
+
+    result = acs(post_request)
+    assert result['Location'] == "default_next_url"
+
+
+@pytest.mark.django_db
+@responses.activate
+def test_acs_view_when_redirection_state_is_passed_in_relay_state(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"): # type: ignore
+    """Test Acs view when login_next_url is None and redirection state in POST request
+    """
+    responses.add(responses.GET, METADATA_URL1, body=METADATA1)
+    settings.SAML2_AUTH = {
+        "ASSERTION_URL": "https://api.example.com",
+        "DEFAULT_NEXT_URL": "default_next_url",
+        "USE_JWT": False,
+        "TRIGGER": {
+            "BEFORE_LOGIN": None,
+            "AFTER_LOGIN": None,
+            "GET_METADATA_AUTO_CONF_URLS": GET_METADATA_AUTO_CONF_URLS
+        }
+    }
+    post_request = RequestFactory().post(METADATA_URL1,
+                                         {"SAMLResponse": "SAML RESPONSE",
+                                          "RelayState": '/admin/logs'})
+
+    monkeypatch.setattr(Saml2Client,
+                        "parse_authn_request_response",
+                        mock_parse_authn_request_response)
+
+    created, mock_user = user.get_or_create_user({
+        "username": "test@example.com",
+        "first_name": "John",
+        "last_name": "Doe"
+    })
+
+    monkeypatch.setattr(user,
+                        "get_or_create_user",
+                        (created, mock_user,))
+
+    middleware = SessionMiddleware(lambda x: None)
+    middleware.process_request(post_request)
+    post_request.session["login_next_url"] = None
+    post_request.session.save()
+
+    result = acs(post_request)
+    assert result['Location'] == "/admin/logs"

--- a/django_saml2_auth/tests/test_saml.py
+++ b/django_saml2_auth/tests/test_saml.py
@@ -394,7 +394,7 @@ def test_extract_user_identity_token_not_required(settings: SettingsWrapper):
 
 @pytest.mark.django_db
 @responses.activate
-def test_acs_view_when_next_url_is_none(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"): # type: ignore
+def test_acs_view_when_next_url_is_none(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"):  # type: ignore
     """Test Acs view when login_next_url is None in the session
     """
     responses.add(responses.GET, METADATA_URL1, body=METADATA1)
@@ -436,7 +436,7 @@ def test_acs_view_when_next_url_is_none(settings: SettingsWrapper, monkeypatch: 
 
 @pytest.mark.django_db
 @responses.activate
-def test_acs_view_when_redirection_state_is_passed_in_relay_state(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"): # type: ignore
+def test_acs_view_when_redirection_state_is_passed_in_relay_state(settings: SettingsWrapper, monkeypatch: "MonkeyPatch"):  # type: ignore
     """Test Acs view when login_next_url is None and redirection state in POST request
     """
     responses.add(responses.GET, METADATA_URL1, body=METADATA1)

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -105,7 +105,7 @@ def acs(request: HttpRequest):
     # login via sp_initiated_login endpoint, or it could be a URL used for redirection.
     relay_state = request.POST.get("RelayState")
     relay_state_is_token = is_jwt_well_formed(relay_state) if relay_state else False
-    if next_url is None and relay_state:
+    if next_url is None and relay_state and not relay_state_is_token:
         next_url = relay_state
     elif next_url is None:
         next_url = get_default_next_url()

--- a/django_saml2_auth/views.py
+++ b/django_saml2_auth/views.py
@@ -95,7 +95,7 @@ def acs(request: HttpRequest):
     # so we can safely ignore the type check here.
     user = extract_user_identity(authn_response.get_identity())  # type: ignore
 
-    next_url = request.session.get("login_next_url") or get_default_next_url()
+    next_url = request.session.get("login_next_url")
 
     # A RelayState is an HTTP parameter that can be included as part of the SAML request
     # and SAML response; usually is meant to be an opaque identifier that is passed back
@@ -105,6 +105,10 @@ def acs(request: HttpRequest):
     # login via sp_initiated_login endpoint, or it could be a URL used for redirection.
     relay_state = request.POST.get("RelayState")
     relay_state_is_token = is_jwt_well_formed(relay_state) if relay_state else False
+    if next_url is None and relay_state:
+        next_url = relay_state
+    elif next_url is None:
+        next_url = get_default_next_url()
 
     if relay_state and relay_state_is_token:
         redirected_user_id = decode_custom_or_default_jwt(relay_state)


### PR DESCRIPTION
I am using MS-AAD, for admin urls such as https://dns/admin/django_celery_beat/periodictask/, I enforce login first. After login, next url is always assigned to default url as code over here.

next_url = request.session.get("login_next_url") or get_default_next_url()

After login, its POST request to acs where new session gets created so request.session.get("login_next_url") is always None. However I observed that in such cases next_url is passed as relay_state.

So to keep existing behaviour and fix the problem, assigning next_url to relay_state if it's None