### PR TITLE
Update README.md - replaced url() with re_path()

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,17 +75,17 @@ python setup.py install
     ```python
     # These are the SAML2 related URLs. You can change "^saml2_auth/" regex to
     # any path you want, like "^sso/", "^sso_auth/", "^sso_login/", etc. (required)
-    url(r'^sso/', include('django_saml2_auth.urls')),
+    re_path(r'^sso/', include('django_saml2_auth.urls')),
 
     # The following line will replace the default user login with SAML2 (optional)
     # If you want to specific the after-login-redirect-URL, use parameter "?next=/the/path/you/want"
     # with this view.
-    url(r'^accounts/login/$', django_saml2_auth.views.signin),
+    re_path(r'^accounts/login/$', django_saml2_auth.views.signin),
 
     # The following line will replace the admin login with SAML2 (optional)
     # If you want to specific the after-login-redirect-URL, use parameter "?next=/the/path/you/want"
     # with this view.
-    url(r'^admin/login/$', django_saml2_auth.views.signin),
+    re_path(r'^admin/login/$', django_saml2_auth.views.signin),
     ```
 
 3. Add `'django_saml2_auth'` to `INSTALLED_APPS` in your django `settings.py`:


### PR DESCRIPTION
The README.md file refers to the django.urls.url() funciton that has been deprecated since Django 3.1: https://docs.djangoproject.com/en/3.1/ref/urls/#url. It can be replaced by django.urls.re_path(): https://docs.djangoproject.com/en/4.2/ref/urls/#re-path

I made that change in the README.md file