### PR TITLE
Fix NameIdFormat policy naming to comply with PySaml2

### DIFF
--- a/django_saml2_auth/saml.py
+++ b/django_saml2_auth/saml.py
@@ -211,7 +211,7 @@ def get_saml_client(domain: str,
 
     name_id_format = saml2_auth_settings.get("NAME_ID_FORMAT")
     if name_id_format:
-        saml_settings["service"]["sp"]["name_id_format"] = name_id_format
+        saml_settings["service"]["sp"]["name_id_policy_format"] = name_id_format
 
     accepted_time_diff = saml2_auth_settings.get("ACCEPTED_TIME_DIFF")
     if accepted_time_diff:


### PR DESCRIPTION
Pysaml2 uses the [name_id_policy_format](https://pysaml2.readthedocs.io/en/latest/howto/config.html#name-id-policy-format) to configure the Saml2 NameId policy (page 50, 3.4.1.1 of the [PDF](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf)). Corps like Okta require this field to be set to properly consume the dynamic server-generated Assertion Consumer Service URLs.

At the moment the `NAME_ID_FORMAT` is not respected by PySaml2 and is set to `None` regardless of what's set here. This change should make it comply again.